### PR TITLE
Add default password for dataverseAdmin account

### DIFF
--- a/kubernetes/controllers/dataverse-rc.yaml
+++ b/kubernetes/controllers/dataverse-rc.yaml
@@ -18,6 +18,8 @@ spec:
         - containerPort: 8080
           protocol: TCP
         env:
+        - name: ADMIN_PASSWORD
+          value: "admin"
         - name: SMTP_HOST
           value: "smtp.ncsa.illinois.edu"
         - name: HOST_DNS_ADDRESS 


### PR DESCRIPTION
Documentation (Dataverse as same as ndslabs-dataverse) specifies an value for dataverseAdmin user: "admin". Deploying the service as is avoids the login with the admin user because Dataverse refuses to connect with an empty password.